### PR TITLE
Crash fix - pydantic settings

### DIFF
--- a/EXPLANATIONS.md
+++ b/EXPLANATIONS.md
@@ -8,3 +8,7 @@ Implemented appointment table and enum in migration with SQLite checks. Added Ap
   - Converted stray `print` statements in `alembic_utils.py` to structured logging.
 - **Other issues found**: updated internal docs and imports to avoid future unresolved-name errors.
 
+## Crash fix July 3
+- **Root cause**: migrating to Pydantic 2 removed `BaseSettings` from the main package.
+- **Fixes applied**: switched imports to `pydantic-settings`, bumped FastAPI, added the new dependency, and corrected two f-string quotes.
+

--- a/api/config.py
+++ b/api/config.py
@@ -1,5 +1,5 @@
-import os
-from pydantic import BaseSettings, Field, HttpUrl, validator
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     # Core application settings

--- a/api/main.py
+++ b/api/main.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
     
     # Configure Hypercorn
     config = Config()
-    config.bind = [f"0.0.0.0:{int(os.getenv("PORT", "8080"))}"]
+    config.bind = [f"0.0.0.0:{int(os.getenv('PORT', '8080'))}"]
     config.use_reloader = True
     
     # Configure Hypercorn logging

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.100.0
+fastapi>=0.111.0
 hypercorn>=0.15.0
 sqlalchemy>=2.0.0
 alembic>=1.11.0
@@ -9,6 +9,7 @@ prometheus-client>=0.17.0
 prometheus-fastapi-instrumentator>=7.1.0
 psycopg2-binary>=2.9.5  # PostgreSQL driver
 pydantic>=2.0.0  # Data validation
+pydantic-settings>=2.0.0
 starlette>=0.27.0  # ASGI framework (FastAPI dependency )
 pgvector>=0.2.0  # Vector support for PostgreSQL
 requests>=2.31.0  # HTTP library for API requests

--- a/api/routers/webhook.py
+++ b/api/routers/webhook.py
@@ -175,7 +175,7 @@ async def process_message(db: Session, tenant: Tenant, message: Dict[str, Any]):
                 db.add(appt)
                 db.commit() # Commit appointment to get its ID if needed later, and ensure it's saved
 
-                reply = f"✅ booked for {starts_at.strftime("%d/%m %H:%M")}. You’ll get a reminder."
+                reply = f"✅ booked for {starts_at.strftime('%d/%m %H:%M')}. You’ll get a reminder."
                 token_count = len(reply.split()) # Simple token count estimation
 
                 bot_message = Message(


### PR DESCRIPTION
## Summary
- switch Settings to use pydantic-settings
- fix f-string quoting in webhook and server start
- require FastAPI >=0.111 and pydantic-settings
- document the fix in EXPLANATIONS

## Testing
- `pyright api/config.py api/main.py api/routers/webhook.py`
- `alembic upgrade head`
- `alembic downgrade -1`
- `hypercorn main:app -k asyncio -b 127.0.0.1:8003`

------
https://chatgpt.com/codex/tasks/task_e_6866d3d8da708327b13ef95badd0ea7f