### PR TITLE
Harden Alembic baseline and migration automation

### DIFF
--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -24,6 +24,32 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f api/requirements.txt ]; then pip install -r api/requirements.txt; else pip install alembic "psycopg[binary]" SQLAlchemy; fi
 
+      - name: Validate DATABASE_URL
+        run: |
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "DATABASE_URL is not configured. Set secrets.DEV_DATABASE_URL." >&2
+            exit 1
+          fi
+          python - <<'PY'
+import os
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
+
+raw_url = os.environ["DATABASE_URL"]
+try:
+    url = make_url(raw_url)
+except ArgumentError as exc:  # pragma: no cover - CI guard
+    raise SystemExit(f"Invalid DATABASE_URL: {exc}")
+
+if url.get_backend_name() != "postgresql":
+    raise SystemExit(f"DATABASE_URL must use the postgresql scheme, got '{url.drivername}'.")
+
+print("Validated DATABASE_URL driver: postgresql")
+PY
+
       - name: Run Alembic upgrade (dev)
         run: |
-          python -m alembic -c api/alembic.ini upgrade head
+          set -euo pipefail
+          CONFIG_PATH="$(realpath api/alembic.ini)"
+          echo "Using Alembic config: ${CONFIG_PATH}"
+          python -m alembic -c "${CONFIG_PATH}" upgrade head

--- a/EXPLANATIONS.md
+++ b/EXPLANATIONS.md
@@ -1,5 +1,11 @@
 Implemented appointment table and enum in migration with SQLite checks. Added Appointment model and exports. Created google calendar helper. Updated webhook with booking regex to store appointments and reply. Verified migrations and hypercorn startup.
 
+## Dec 22 2025 · Alembic hardening
+- Enforced a Postgres-only `DATABASE_URL` in Alembic's env, with structured logging for resolved targets and online/offline execution.
+- Wrapped the squashed baseline in inspector-driven guards so enums, extensions, tables, indexes, and exclusion constraints are idempotent and logged.
+- Gated startup migrations behind `RUN_MIGRATIONS_ON_STARTUP`, tightened the dev workflow with Postgres validation, and surfaced the Alembic config path.
+- Documented how to run migrations locally and on Railway, keeping downgrade helpers tolerant of missing schema objects.
+
 ## July 3 Hotfix
 - **Root cause**: `FAQ` model wasn't imported in `api/ai.py`, causing a `NameError` during startup.
 - **Fixes applied**:

--- a/README.md
+++ b/README.md
@@ -57,3 +57,23 @@ The multi-stage Dockerfile installs Python deps once (layer cache) and copies so
 - The shared dev database was reset and now boots from the squashed Alembic baseline `001_initial_squashed`.
 - To recreate the schema locally, export `DATABASE_URL` with the dev connection string and run `alembic -c api/alembic.ini upgrade head`.
 - For any future schema change, add a brand-new Alembic revision—never edit or replace `001_initial_squashed`.
+
+## Database migrations
+
+- Alembic lives under `api/alembic/` with the entry configuration at `api/alembic.ini` and migrations in `api/alembic/versions/`.
+- `DATABASE_URL` must point to PostgreSQL (e.g. `postgresql://...`). Alembic and the app will fail fast if the URL is missing or uses another dialect.
+- Run migrations locally with:
+
+  ```bash
+  export DATABASE_URL=postgresql://...  # Postgres only
+  alembic -c api/alembic.ini upgrade head
+  ```
+
+- Railway one-off deploys can apply migrations via:
+
+  ```bash
+  railway run --service api "alembic -c api/alembic.ini upgrade head"
+  ```
+
+- The API no longer runs Alembic automatically. Set `RUN_MIGRATIONS_ON_STARTUP=true` only when you explicitly want startup to run `upgrade head` (default is `false`).
+- CI keeps the dev database up to date through `.github/workflows/migrate-dev.yml`, which validates `secrets.DEV_DATABASE_URL` and runs `alembic -c api/alembic.ini upgrade head` on every push to `dev` or manual dispatch.

--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -1,8 +1,8 @@
 # A generic, single database configuration.
 
 [alembic]
-# path to migration scripts
-script_location = alembic
+# path to migration scripts (resolved relative to this file)
+script_location = %(here)s/alembic
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
@@ -34,8 +34,6 @@ script_location = alembic
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8
-
-sqlalchemy.url = %(DATABASE_URL)s
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -1,61 +1,88 @@
-from logging.config import fileConfig
+"""Alembic environment configuration for Lumi."""
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
-import sqlalchemy as sa
+from __future__ import annotations
+
 import os
 import sys
+from logging.config import fileConfig
+from pathlib import Path
 
+import sqlalchemy as sa
 from alembic import context
+from logging_utils import get_logger
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import ArgumentError
 
-# Add parent directory to path so we can import project modules.
-base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if base_dir not in sys.path:
-    sys.path.append(base_dir)
+BASE_DIR = Path(__file__).resolve().parent.parent
+if str(BASE_DIR) not in sys.path:
+    sys.path.append(str(BASE_DIR))
 
-# Import metadata and models so Alembic sees every table definition.
-from database import Base
-import models  # noqa: F401  # Imported for side-effects so metadata is populated.
+logger = get_logger("alembic.env")
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
 config = context.config
 
-# Get database URL from environment variable
-config.set_main_option("sqlalchemy.url", os.environ.get("DATABASE_URL", ""))
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
+def _resolve_database_url() -> str:
+    raw_url = os.environ.get("DATABASE_URL")
+    if not raw_url:
+        message = (
+            "DATABASE_URL is required to run Alembic migrations. "
+            "Set it to a PostgreSQL connection string (postgresql://)."
+        )
+        logger.error(message)
+        raise RuntimeError(message)
+
+    try:
+        parsed_url: URL = make_url(raw_url)
+    except ArgumentError as exc:  # pragma: no cover - defensive guard
+        message = "DATABASE_URL is not a valid SQLAlchemy URL."
+        logger.error(message, extra={"error": str(exc)})
+        raise RuntimeError(f"{message} ({exc})") from exc
+
+    if parsed_url.get_backend_name() != "postgresql":
+        message = (
+            "DATABASE_URL must use the 'postgresql' scheme. "
+            f"Received '{parsed_url.drivername}'."
+        )
+        logger.error(message)
+        raise RuntimeError(message)
+
+    logger.info(
+        "Resolved DATABASE_URL for Alembic",
+        extra={"url": parsed_url.render_as_string(hide_password=True)},
+    )
+    return raw_url
+
+
+DATABASE_URL = _resolve_database_url()
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
+try:
+    from database import Base
+    import models  # noqa: F401  # Import side effects so metadata is populated
+except Exception as exc:  # pragma: no cover - defensive guard
+    logger.error(
+        "Failed to import application metadata for Alembic.",
+        extra={"error": str(exc)},
+        exc_info=exc,
+    )
+    raise
+
+
 target_metadata = Base.metadata
-
 DEFAULT_SCHEMA = "public"
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
 
 
 def run_migrations_offline() -> None:
-    """Run migrations in 'offline' mode.
+    """Run migrations in 'offline' mode."""
 
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
-    url = config.get_main_option("sqlalchemy.url")
+    logger.info("Running Alembic migrations (offline mode)")
     context.configure(
-        url=url,
+        url=DATABASE_URL,
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -63,16 +90,15 @@ def run_migrations_offline() -> None:
     )
 
     with context.begin_transaction():
+        logger.info("Applying migrations", extra={"mode": "offline"})
         context.run_migrations()
+        logger.info("Migrations applied", extra={"mode": "offline"})
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+    """Run migrations in 'online' mode."""
 
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
+    logger.info("Running Alembic migrations (online mode)")
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -90,7 +116,9 @@ def run_migrations_online() -> None:
         )
 
         with context.begin_transaction():
+            logger.info("Applying migrations", extra={"mode": "online"})
             context.run_migrations()
+            logger.info("Migrations applied", extra={"mode": "online"})
 
 
 if context.is_offline_mode():

--- a/api/alembic/versions/001_initial_squashed.py
+++ b/api/alembic/versions/001_initial_squashed.py
@@ -8,6 +8,8 @@ import sqlalchemy as sa
 from alembic import op
 from pgvector.sqlalchemy import Vector
 
+from logging_utils import get_logger
+
 revision = "001_initial_squashed"
 down_revision = None
 branch_labels = None
@@ -18,20 +20,35 @@ VECTOR_EXTENSION = "vector"
 BTREE_GIST_EXTENSION = "btree_gist"
 UNAVAILABILITY_EXCLUSION = "uq_unavailability_owner_dates"
 
+logger = get_logger("alembic.001_initial_squashed")
+
 
 def _ensure_extension(extension: str) -> None:
     bind = op.get_bind()
-    if bind.dialect.name != "postgresql":
+    dialect = bind.dialect.name
+    if dialect != "postgresql":
+        logger.info(
+            "Skipping extension on non-PostgreSQL dialect",
+            extra={"extension": extension, "dialect": dialect},
+        )
         return
-    op.execute(sa.text(f"CREATE EXTENSION IF NOT EXISTS {extension}"))
+
+    logger.info("Ensuring extension exists", extra={"extension": extension})
+    op.execute(sa.text(f'CREATE EXTENSION IF NOT EXISTS "{extension}"'))
 
 
 def _ensure_enum(name: str, values: Sequence[str]) -> None:
     bind = op.get_bind()
-    if bind.dialect.name != "postgresql":
+    dialect = bind.dialect.name
+    if dialect != "postgresql":
+        logger.info(
+            "Skipping enum creation on non-PostgreSQL dialect",
+            extra={"enum": name, "dialect": dialect},
+        )
         return
 
     quoted_values = ", ".join(f"'{value}'" for value in values)
+    logger.info("Ensuring enum exists", extra={"enum": name})
     op.execute(
         sa.text(
             f"""
@@ -61,8 +78,154 @@ def _build_enum(name: str, values: Sequence[str]) -> sa.Enum:
     return sa.Enum(*values, **enum_kwargs)
 
 
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return inspector.has_table(table_name, schema=SCHEMA)
+
+
+def _index_exists(bind: sa.engine.Connection, table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    indexes = inspector.get_indexes(table_name, schema=SCHEMA)
+    return any(idx["name"] == index_name for idx in indexes)
+
+
+def _constraint_exists(bind: sa.engine.Connection, constraint_name: str) -> bool:
+    if bind.dialect.name != "postgresql":
+        return False
+    result = bind.execute(
+        sa.text(
+            """
+            SELECT 1
+            FROM pg_constraint c
+            JOIN pg_namespace n ON n.oid = c.connamespace
+            WHERE c.conname = :constraint_name AND n.nspname = :schema_name
+            """
+        ),
+        {"constraint_name": constraint_name, "schema_name": SCHEMA},
+    )
+    return result.scalar() is not None
+
+
+def _create_index_if_missing(
+    bind: sa.engine.Connection,
+    index_name: str,
+    table_name: str,
+    columns: Sequence[str],
+    *,
+    unique: bool = False,
+) -> None:
+    if _index_exists(bind, table_name, index_name):
+        logger.info(
+            "Index already exists; skipping create",
+            extra={"table": f"{SCHEMA}.{table_name}", "index": index_name},
+        )
+        return
+
+    logger.info(
+        "Creating index",
+        extra={"table": f"{SCHEMA}.{table_name}", "index": index_name},
+    )
+    op.create_index(index_name, table_name, list(columns), unique=unique, schema=SCHEMA)
+
+
+def _drop_index_if_exists(
+    bind: sa.engine.Connection,
+    index_name: str,
+    table_name: str,
+) -> None:
+    if not _table_exists(bind, table_name):
+        logger.info(
+            "Skipping drop index; table missing",
+            extra={"table": f"{SCHEMA}.{table_name}", "index": index_name},
+        )
+        return
+    if not _index_exists(bind, table_name, index_name):
+        logger.info(
+            "Skipping drop index; index missing",
+            extra={"table": f"{SCHEMA}.{table_name}", "index": index_name},
+        )
+        return
+
+    logger.info(
+        "Dropping index",
+        extra={"table": f"{SCHEMA}.{table_name}", "index": index_name},
+    )
+    op.drop_index(index_name, table_name=table_name, schema=SCHEMA)
+
+
+def _drop_table_if_exists(bind: sa.engine.Connection, table_name: str) -> None:
+    if not _table_exists(bind, table_name):
+        logger.info(
+            "Skipping drop table; already absent",
+            extra={"table": f"{SCHEMA}.{table_name}"},
+        )
+        return
+
+    logger.info("Dropping table", extra={"table": f"{SCHEMA}.{table_name}"})
+    op.drop_table(table_name, schema=SCHEMA)
+
+
+def _ensure_unavailability_constraint(bind: sa.engine.Connection) -> None:
+    if bind.dialect.name != "postgresql":
+        logger.info(
+            "Skipping exclusion constraint on non-PostgreSQL dialect",
+            extra={"constraint": UNAVAILABILITY_EXCLUSION},
+        )
+        return
+
+    if _constraint_exists(bind, UNAVAILABILITY_EXCLUSION):
+        logger.info(
+            "Exclusion constraint already exists; skipping create",
+            extra={"constraint": UNAVAILABILITY_EXCLUSION},
+        )
+        return
+
+    logger.info(
+        "Creating exclusion constraint",
+        extra={"constraint": UNAVAILABILITY_EXCLUSION},
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE "{SCHEMA}"."unavailability"
+            ADD CONSTRAINT {UNAVAILABILITY_EXCLUSION}
+            EXCLUDE USING gist (
+                tenant_id WITH =,
+                owner_phone WITH =,
+                daterange(starts_on, ends_on, '[]') WITH &&
+            )
+            """
+        )
+    )
+
+
+def _drop_unavailability_constraint(bind: sa.engine.Connection) -> None:
+    if bind.dialect.name != "postgresql":
+        return
+    if not _constraint_exists(bind, UNAVAILABILITY_EXCLUSION):
+        logger.info(
+            "Skipping drop constraint; already absent",
+            extra={"constraint": UNAVAILABILITY_EXCLUSION},
+        )
+        return
+
+    logger.info(
+        "Dropping exclusion constraint",
+        extra={"constraint": UNAVAILABILITY_EXCLUSION},
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE "{SCHEMA}"."unavailability"
+            DROP CONSTRAINT {UNAVAILABILITY_EXCLUSION}
+            """
+        )
+    )
+
+
 def upgrade() -> None:
     bind = op.get_bind()
+    logger.info("Starting baseline upgrade", extra={"schema": SCHEMA})
 
     _ensure_extension(VECTOR_EXTENSION)
     _ensure_extension(BTREE_GIST_EXTENSION)
@@ -72,357 +235,317 @@ def upgrade() -> None:
         "appt_status_enum", ["pending", "confirmed", "cancelled"]
     )
 
-    op.create_table(
-        "tenants",
-        sa.Column("id", sa.String(length=255), nullable=False),
-        sa.Column("phone_id", sa.String(length=255), nullable=False),
-        sa.Column("wh_token", sa.Text(), nullable=False),
-        sa.Column(
-            "system_prompt",
-            sa.Text(),
-            nullable=False,
-            server_default="You are a helpful assistant.",
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
-        op.f("ix_tenants_id"),
-        "tenants",
-        ["id"],
-        unique=False,
-        schema=SCHEMA,
-    )
-    op.create_index(
+    if not _table_exists(bind, "tenants"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.tenants"})
+        op.create_table(
+            "tenants",
+            sa.Column("id", sa.String(length=255), nullable=False),
+            sa.Column("phone_id", sa.String(length=255), nullable=False),
+            sa.Column("wh_token", sa.Text(), nullable=False),
+            sa.Column(
+                "system_prompt",
+                sa.Text(),
+                nullable=False,
+                server_default="You are a helpful assistant.",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.tenants"},
+        )
+
+    _create_index_if_missing(bind, op.f("ix_tenants_id"), "tenants", ["id"])
+    _create_index_if_missing(
+        bind,
         "uq_tenants_phone_id",
         "tenants",
         ["phone_id"],
         unique=True,
-        schema=SCHEMA,
     )
 
-    op.create_table(
-        "messages",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("wa_msg_id", sa.String(length=255), nullable=True),
-        sa.Column("role", role_enum, nullable=False),
-        sa.Column("text", sa.Text(), nullable=False),
-        sa.Column("tokens", sa.Integer(), nullable=True),
-        sa.Column(
-            "ts",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("wa_msg_id", name="uq_messages_wa_msg_id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
-        op.f("ix_messages_tenant_id"),
-        "messages",
-        ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
-    )
+    if not _table_exists(bind, "messages"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.messages"})
+        op.create_table(
+            "messages",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("wa_msg_id", sa.String(length=255), nullable=True),
+            sa.Column("role", role_enum, nullable=False),
+            sa.Column("text", sa.Text(), nullable=False),
+            sa.Column("tokens", sa.Integer(), nullable=True),
+            sa.Column(
+                "ts",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("wa_msg_id", name="uq_messages_wa_msg_id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.messages"},
+        )
 
-    op.create_table(
-        "faqs",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("question", sa.String(length=500), nullable=False),
-        sa.Column("answer", sa.Text(), nullable=False),
-        sa.Column("embedding", Vector(1536), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
-        op.f("ix_faqs_tenant_id"),
-        "faqs",
-        ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
-    )
+    _create_index_if_missing(bind, op.f("ix_messages_tenant_id"), "messages", ["tenant_id"])
 
-    op.create_table(
-        "usage",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("direction", sa.String(length=64), nullable=True),
-        sa.Column(
-            "msg_ts",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.Column("tokens", sa.Integer(), nullable=True),
-        sa.Column("model", sa.String(length=255), nullable=True),
-        sa.Column(
-            "prompt_tokens",
-            sa.Integer(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "completion_tokens",
-            sa.Integer(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column(
-            "total_tokens",
-            sa.Integer(),
-            nullable=False,
-            server_default=sa.text("0"),
-        ),
-        sa.Column("trace_id", sa.String(length=255), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
-        op.f("ix_usage_tenant_id"),
-        "usage",
-        ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
-    )
-    op.create_index(
+    if not _table_exists(bind, "faqs"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.faqs"})
+        op.create_table(
+            "faqs",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("question", sa.String(length=500), nullable=False),
+            sa.Column("answer", sa.Text(), nullable=False),
+            sa.Column("embedding", Vector(1536), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.faqs"},
+        )
+
+    _create_index_if_missing(bind, op.f("ix_faqs_tenant_id"), "faqs", ["tenant_id"])
+
+    if not _table_exists(bind, "usage"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.usage"})
+        op.create_table(
+            "usage",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("direction", sa.String(length=64), nullable=True),
+            sa.Column("tokens", sa.Integer(), nullable=True),
+            sa.Column(
+                "msg_ts",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("model", sa.String(length=255), nullable=True),
+            sa.Column(
+                "prompt_tokens",
+                sa.Integer(),
+                nullable=False,
+                default=0,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "completion_tokens",
+                sa.Integer(),
+                nullable=False,
+                default=0,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "total_tokens",
+                sa.Integer(),
+                nullable=False,
+                default=0,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("trace_id", sa.String(length=255), nullable=True),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.usage"},
+        )
+
+    _create_index_if_missing(bind, op.f("ix_usage_tenant_id"), "usage", ["tenant_id"])
+    _create_index_if_missing(
+        bind,
         "ix_usage_tenant_id_msg_ts",
         "usage",
         ["tenant_id", "msg_ts"],
-        unique=False,
-        schema=SCHEMA,
     )
-    op.create_index(
+    _create_index_if_missing(
+        bind,
         "ix_usage_tenant_id_id",
         "usage",
         ["tenant_id", "id"],
-        unique=False,
-        schema=SCHEMA,
     )
 
-    op.create_table(
-        "appointments",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("customer_phone", sa.String(length=50), nullable=False),
-        sa.Column("customer_email", sa.String(length=255), nullable=True),
-        sa.Column("starts_at", sa.TIMESTAMP(timezone=True), nullable=False),
-        sa.Column(
-            "status",
-            appt_status_enum,
-            nullable=False,
-            server_default="pending",
-        ),
-        sa.Column("google_event_id", sa.String(length=255), nullable=True),
-        sa.Column(
-            "reminded",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("false"),
-        ),
-        sa.Column(
-            "created_ts",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
-        op.f("ix_appointments_tenant_id"),
-        "appointments",
-        ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
-    )
+    if not _table_exists(bind, "appointments"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.appointments"})
+        op.create_table(
+            "appointments",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("customer_phone", sa.String(length=50), nullable=False),
+            sa.Column("customer_email", sa.String(length=255), nullable=True),
+            sa.Column("starts_at", sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.Column(
+                "status",
+                appt_status_enum,
+                nullable=False,
+                server_default=sa.text("'pending'"),
+            ),
+            sa.Column("google_event_id", sa.String(length=255), nullable=True),
+            sa.Column(
+                "reminded",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+            sa.Column(
+                "created_ts",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.appointments"},
+        )
 
-    op.create_table(
-        "owner_contacts",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("phone_number", sa.String(length=64), nullable=False),
-        sa.Column("display_name", sa.String(length=255), nullable=True),
-        sa.Column(
-            "created_ts",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
+    _create_index_if_missing(bind, op.f("ix_appointments_tenant_id"), "appointments", ["tenant_id"])
+
+    if not _table_exists(bind, "owner_contacts"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.owner_contacts"})
+        op.create_table(
+            "owner_contacts",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("phone_number", sa.String(length=64), nullable=False),
+            sa.Column("display_name", sa.String(length=255), nullable=True),
+            sa.Column(
+                "created_ts",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.owner_contacts"},
+        )
+
+    _create_index_if_missing(
+        bind,
         op.f("ix_owner_contacts_tenant_id"),
         "owner_contacts",
         ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
     )
-    op.create_index(
+    _create_index_if_missing(
+        bind,
         op.f("ix_owner_contacts_phone_number"),
         "owner_contacts",
         ["phone_number"],
-        unique=False,
-        schema=SCHEMA,
     )
 
-    op.create_table(
-        "unavailability",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("tenant_id", sa.String(length=255), nullable=False),
-        sa.Column("owner_phone", sa.String(length=64), nullable=False),
-        sa.Column("starts_on", sa.DATE(), nullable=False),
-        sa.Column("ends_on", sa.DATE(), nullable=False),
-        sa.Column(
-            "created_ts",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
-        sa.ForeignKeyConstraint(
-            ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
-        ),
-        sa.PrimaryKeyConstraint("id"),
-        schema=SCHEMA,
-    )
-    op.create_index(
+    if not _table_exists(bind, "unavailability"):
+        logger.info("Creating table", extra={"table": f"{SCHEMA}.unavailability"})
+        op.create_table(
+            "unavailability",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("tenant_id", sa.String(length=255), nullable=False),
+            sa.Column("owner_phone", sa.String(length=64), nullable=False),
+            sa.Column("starts_on", sa.DATE(), nullable=False),
+            sa.Column("ends_on", sa.DATE(), nullable=False),
+            sa.Column(
+                "created_ts",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["tenant_id"], [f"{SCHEMA}.tenants.id"], ondelete="CASCADE"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            schema=SCHEMA,
+        )
+    else:
+        logger.info(
+            "Table already exists; skipping create",
+            extra={"table": f"{SCHEMA}.unavailability"},
+        )
+
+    _create_index_if_missing(
+        bind,
         op.f("ix_unavailability_tenant_id"),
         "unavailability",
         ["tenant_id"],
-        unique=False,
-        schema=SCHEMA,
     )
-    op.create_index(
+    _create_index_if_missing(
+        bind,
         "ix_unavailability_tenant_dates",
         "unavailability",
         ["tenant_id", "starts_on", "ends_on"],
-        unique=False,
-        schema=SCHEMA,
     )
 
-    if bind.dialect.name == "postgresql":
-        op.execute(
-            sa.text(
-                f"""
-                ALTER TABLE "{SCHEMA}"."unavailability"
-                ADD CONSTRAINT {UNAVAILABILITY_EXCLUSION}
-                EXCLUDE USING gist (
-                    tenant_id WITH =,
-                    owner_phone WITH =,
-                    daterange(starts_on, ends_on, '[]') WITH &&
-                )
-                """
-            )
-        )
+    _ensure_unavailability_constraint(bind)
+
+    logger.info("Baseline upgrade complete", extra={"schema": SCHEMA})
 
 
 def downgrade() -> None:
     bind = op.get_bind()
+    logger.info("Starting baseline downgrade", extra={"schema": SCHEMA})
+
+    _drop_unavailability_constraint(bind)
+
+    _drop_index_if_exists(bind, "ix_unavailability_tenant_dates", "unavailability")
+    _drop_index_if_exists(bind, op.f("ix_unavailability_tenant_id"), "unavailability")
+    _drop_table_if_exists(bind, "unavailability")
+
+    _drop_index_if_exists(bind, op.f("ix_owner_contacts_phone_number"), "owner_contacts")
+    _drop_index_if_exists(bind, op.f("ix_owner_contacts_tenant_id"), "owner_contacts")
+    _drop_table_if_exists(bind, "owner_contacts")
+
+    _drop_index_if_exists(bind, op.f("ix_appointments_tenant_id"), "appointments")
+    _drop_table_if_exists(bind, "appointments")
+
+    _drop_index_if_exists(bind, "ix_usage_tenant_id_id", "usage")
+    _drop_index_if_exists(bind, "ix_usage_tenant_id_msg_ts", "usage")
+    _drop_index_if_exists(bind, op.f("ix_usage_tenant_id"), "usage")
+    _drop_table_if_exists(bind, "usage")
+
+    _drop_index_if_exists(bind, op.f("ix_faqs_tenant_id"), "faqs")
+    _drop_table_if_exists(bind, "faqs")
+
+    _drop_index_if_exists(bind, op.f("ix_messages_tenant_id"), "messages")
+    _drop_table_if_exists(bind, "messages")
+
+    _drop_index_if_exists(bind, "uq_tenants_phone_id", "tenants")
+    _drop_index_if_exists(bind, op.f("ix_tenants_id"), "tenants")
+    _drop_table_if_exists(bind, "tenants")
 
     if bind.dialect.name == "postgresql":
-        op.execute(
-            sa.text(
-                f"""
-                ALTER TABLE "{SCHEMA}"."unavailability"
-                DROP CONSTRAINT IF EXISTS {UNAVAILABILITY_EXCLUSION}
-                """
-            )
-        )
+        logger.info("Dropping enums and extensions", extra={"schema": SCHEMA})
+        op.execute(sa.text(f'DROP TYPE IF EXISTS "{SCHEMA}"."appt_status_enum"'))
+        op.execute(sa.text(f'DROP TYPE IF EXISTS "{SCHEMA}"."role_enum"'))
+        op.execute(sa.text(f'DROP EXTENSION IF EXISTS "{VECTOR_EXTENSION}"'))
+        op.execute(sa.text(f'DROP EXTENSION IF EXISTS "{BTREE_GIST_EXTENSION}"'))
 
-    op.drop_index(
-        "ix_unavailability_tenant_dates",
-        table_name="unavailability",
-        schema=SCHEMA,
-    )
-    op.drop_index(
-        op.f("ix_unavailability_tenant_id"),
-        table_name="unavailability",
-        schema=SCHEMA,
-    )
-    op.drop_table("unavailability", schema=SCHEMA)
-
-    op.drop_index(
-        op.f("ix_owner_contacts_phone_number"),
-        table_name="owner_contacts",
-        schema=SCHEMA,
-    )
-    op.drop_index(
-        op.f("ix_owner_contacts_tenant_id"),
-        table_name="owner_contacts",
-        schema=SCHEMA,
-    )
-    op.drop_table("owner_contacts", schema=SCHEMA)
-
-    op.drop_index(
-        op.f("ix_appointments_tenant_id"),
-        table_name="appointments",
-        schema=SCHEMA,
-    )
-    op.drop_table("appointments", schema=SCHEMA)
-
-    op.drop_index(
-        "ix_usage_tenant_id_id",
-        table_name="usage",
-        schema=SCHEMA,
-    )
-    op.drop_index(
-        "ix_usage_tenant_id_msg_ts",
-        table_name="usage",
-        schema=SCHEMA,
-    )
-    op.drop_index(
-        op.f("ix_usage_tenant_id"),
-        table_name="usage",
-        schema=SCHEMA,
-    )
-    op.drop_table("usage", schema=SCHEMA)
-
-    op.drop_index(
-        op.f("ix_faqs_tenant_id"),
-        table_name="faqs",
-        schema=SCHEMA,
-    )
-    op.drop_table("faqs", schema=SCHEMA)
-
-    op.drop_index(
-        op.f("ix_messages_tenant_id"),
-        table_name="messages",
-        schema=SCHEMA,
-    )
-    op.drop_table("messages", schema=SCHEMA)
-
-    op.drop_index(
-        "uq_tenants_phone_id",
-        table_name="tenants",
-        schema=SCHEMA,
-    )
-    op.drop_index(
-        op.f("ix_tenants_id"),
-        table_name="tenants",
-        schema=SCHEMA,
-    )
-    op.drop_table("tenants", schema=SCHEMA)
-
-    if bind.dialect.name == "postgresql":
-        op.execute(sa.text(f"DROP TYPE IF EXISTS {SCHEMA}.appt_status_enum"))
-        op.execute(sa.text(f"DROP TYPE IF EXISTS {SCHEMA}.role_enum"))
-        op.execute(sa.text(f"DROP EXTENSION IF EXISTS {VECTOR_EXTENSION}"))
-        op.execute(sa.text(f"DROP EXTENSION IF EXISTS {BTREE_GIST_EXTENSION}"))
+    logger.info("Baseline downgrade complete", extra={"schema": SCHEMA})

--- a/api/config.py
+++ b/api/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     PROJECT_VERSION: str = "0.1.0"
 
     DATABASE_URL: str
+    RUN_MIGRATIONS_ON_STARTUP: bool = False
 
     REDIS_URL: str | None = None
     REDIS_DB: int | None = None


### PR DESCRIPTION
## Summary
- enforce PostgreSQL-only DATABASE_URL resolution in Alembic, add structured logging, and remove sqlite fallbacks
- rebuild the 001_initial_squashed baseline with inspector guards for extensions, enums, tables, indexes, and exclusion constraints
- gate startup migrations behind RUN_MIGRATIONS_ON_STARTUP, document the flow, and harden the dev migration workflow with DATABASE_URL validation

